### PR TITLE
Fixed bug that caused the app to crash when selecting an image

### DIFF
--- a/app/src/main/java/edu/temple/phototag/MainActivity.java
+++ b/app/src/main/java/edu/temple/phototag/MainActivity.java
@@ -133,7 +133,7 @@ public class MainActivity extends AppCompatActivity implements GalleryViewFragme
 
         //begin fragment
         fm.beginTransaction()
-                .add(R.id.gallery,singlePhotoViewFragment)
+                .replace(R.id.gallery,singlePhotoViewFragment)
                 .addToBackStack(null)
                 .commit();
     }


### PR DESCRIPTION
removed the line to hide the gallery view fragment, caused crash when a photo is clicked