### PR TITLE
ML calls now except photos - Gallery loads correctly on first launch/sign-in

### DIFF
--- a/app/src/main/java/edu/temple/phototag/MLKitProcess.java
+++ b/app/src/main/java/edu/temple/phototag/MLKitProcess.java
@@ -151,6 +151,10 @@ public class MLKitProcess {
         labelBitmap(bitmap);
     }
 
+    public static void labelImage(Photo photo){
+        labelBitmap(BitmapFactory.decodeFile(photo.path));
+    }
+
 
     /**
      *
@@ -163,6 +167,12 @@ public class MLKitProcess {
     public static void autoLabelPhotos(Photo[] photos, String[] paths){
         for(int i = 0; i < photos.length; i++){
             autoLabelBitmap(photos[i], paths[i], labeler);
+        }
+    }
+
+    public static void autoLabelPhotos(Photo[] photos){
+        for(int i = 0; i < photos.length; i++){
+            autoLabelBitmap(photos[i], photos[i].path, labeler);
         }
     }
 }

--- a/app/src/main/java/edu/temple/phototag/MLKitProcess.java
+++ b/app/src/main/java/edu/temple/phototag/MLKitProcess.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 public class MLKitProcess {
 
-    static float minConfidenceScore = 0.825f;
+    static float minConfidenceScore = 0.7f;
     static int rotation = 0;
     static String[] autoLabels = new String[10];
     static ImageLabelerOptions options = new ImageLabelerOptions.Builder()
@@ -91,20 +91,18 @@ public class MLKitProcess {
      * photo object given they are not already a tag for the photo
      */
     public static void autoLabelBitmap(Photo photo, String path, ImageLabeler labeler){
-        for(int r = 0; r < 360; r+=90) {
-            //prepare image
-            InputImage inputImage = InputImage.fromBitmap(BitmapFactory.decodeFile(path), r);
-            //utilize callback interface to catch labels being returned by MLKit
-            findLabels(inputImage, labeler, new LabelCallback() {
-                @Override
-                public void onCallback(String value) {
-                    ArrayList<String> tags = photo.getTags();
-                    if (!tags.contains(value)) {
-                        photo.addTag(value);
-                    }
+        //prepare image
+        InputImage inputImage = InputImage.fromBitmap(BitmapFactory.decodeFile(path), 0);
+        //utilize callback interface to catch labels being returned by MLKit
+        findLabels(inputImage, labeler, new LabelCallback() {
+            @Override
+            public void onCallback(String value) {
+                ArrayList<String> tags = photo.getTags();
+                if (!tags.contains(value)) {
+                    photo.addTag(value);
                 }
-            });
-        }
+            }
+        });
     }
 
 
@@ -118,11 +116,12 @@ public class MLKitProcess {
      */
     public static void findLabels(InputImage inputImage, ImageLabeler labeler, LabelCallback labelCallback){
         Task<List<ImageLabel>> result = labeler.process(inputImage)
-                .addOnSuccessListener(new OnSuccessListener<List<ImageLabel>>() { //this asynchronus stuff is kicking my ass
+                .addOnSuccessListener(new OnSuccessListener<List<ImageLabel>>() {
                     @Override
                     public void onSuccess(List<ImageLabel> labels) {
                         // Task completed successfully
                         // For each label:get the text, send text to callback function
+                        // (should be changed to send array of text to callback)
                         for(ImageLabel label : labels) {
                             String text = label.getText();
                             labelCallback.onCallback(text);
@@ -151,13 +150,20 @@ public class MLKitProcess {
         labelBitmap(bitmap);
     }
 
+    /**
+     *New version of {@link MLKitProcess#labelImage(Bitmap)} to use photo objects
+     *
+     * @param photo
+     * @return void
+     *      for getting labels for a photo being displayed in single photo view
+     *      uses callbacks to apply the label suggestions as they are recieved
+     */
     public static void labelImage(Photo photo){
         labelBitmap(BitmapFactory.decodeFile(photo.path));
     }
 
 
     /**
-     *
      * @param photos
      * @param paths
      * @return void
@@ -170,6 +176,13 @@ public class MLKitProcess {
         }
     }
 
+    /**
+     * New version of {@link MLKitProcess#autoLabelPhotos(Photo[], String[])} to use just photo objects
+     *
+     * @param photos
+     *      for labeling an array of photo objects
+     *      to do so their corresponding local storage paths are needed
+     */
     public static void autoLabelPhotos(Photo[] photos){
         for(int i = 0; i < photos.length; i++){
             autoLabelBitmap(photos[i], photos[i].path, labeler);

--- a/app/src/main/java/edu/temple/phototag/MLKitProcess.java
+++ b/app/src/main/java/edu/temple/phototag/MLKitProcess.java
@@ -54,8 +54,10 @@ public class MLKitProcess {
             findLabels(inputImage, labeler, new LabelCallback() {
                 @Override
                 public void onCallback(String value) {
+                    //create string array to hold tags
                     String[] tagArr = SinglePhotoViewFragment.autoTags;
 
+                    //for each item in the string array
                     for (int i = 0; i < tagArr.length; i++) {
                         if (tagArr[i] == null) {
                             tagArr[i] = value;
@@ -63,9 +65,8 @@ public class MLKitProcess {
                             String[] out = Arrays.copyOfRange(tagArr, 0, i + 1);
                             String tags = String.join(",", (out));
 
-                            //update textview with tags
+                            //display the updated array of tags
                             SinglePhotoViewFragment.sugTag.setText(tags);
-                            //end for statement since only 1 label is returned at a time
                             break;
                         } else {
                             if (tagArr[i].equals(value)) {

--- a/app/src/main/java/edu/temple/phototag/MainActivity.java
+++ b/app/src/main/java/edu/temple/phototag/MainActivity.java
@@ -338,6 +338,7 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
         //names = new String[count];
 
         //loop through images on device and add paths to array
+        //should be changed to create a photo array
         for (int i = 0; i < count; i++) {
             cursor.moveToPosition(i);
             int dataColumnIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA);
@@ -349,20 +350,17 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
         }
         cursor.close();
 
-        //get preferences
 
-
-
+        //create user
         acct = GoogleSignIn.getLastSignedInAccount(this);
         User userObj = new User(acct.getDisplayName(), acct.getEmail(), arrPath);
 
-
+        //get preferences
         SharedPreferences shPref = PreferenceManager.getDefaultSharedPreferences(this);
         //Handle auto tagging on device but not auto tagging off device
         if(shPref.getBoolean("autoTagSwitch", false) && !shPref.getBoolean("serverTagSwitch", false)) {
             Photo[] photos = new Photo[count]; //photo array to hold corrosponding arrPath information
             for (int i = 0; i < count; i++) {  //for each path/photo
-                //String[] idArray = arrPath[i].split("/");
                 Photo photo = new Photo(arrPath[i], null, null, null);
                 photos[i] = photo;  //add photo to array
             }

--- a/app/src/main/java/edu/temple/phototag/MainActivity.java
+++ b/app/src/main/java/edu/temple/phototag/MainActivity.java
@@ -79,7 +79,7 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
             //callback
         }
 
-
+        /*
         final String[] columns = {MediaStore.Images.Media.DATA, MediaStore.Images.Media._ID};
         final String orderBy = MediaStore.Images.Media._ID;
 
@@ -107,6 +107,8 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
         }
         cursor.close();
 
+         */
+
         fm = getSupportFragmentManager();
 
         loginViewFragment = (LoginFragment) fm.findFragmentById(R.id.main);
@@ -117,10 +119,13 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
             fm.beginTransaction().add(R.id.main, LoginFragment.newInstance()).commit();
         }
 
+        //}
+
+        /* AutoTagging
         //get preferences
         SharedPreferences shPref = PreferenceManager.getDefaultSharedPreferences(this);
         //Handle auto tagging on device but not auto tagging off device
-        if(shPref.getBoolean("autoTagSwitch", false) && !shPref.getBoolean("serverTagSwitch", false)) {
+            if(shPref.getBoolean("autoTagSwitch", false) && !shPref.getBoolean("serverTagSwitch", false)) {
             Photo[] photos = new Photo[count]; //photo array to hold corrosponding arrPath information
             for (int i = 0; i < count; i++) {  //for each path/photo
                 //String[] idArray = arrPath[i].split("/");
@@ -128,8 +133,9 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
                 photos[i] = photo;  //add photo to array
             }
             //send photos/paths to be labeled automatically
-            MLKitProcess.autoLabelPhotos(photos);
+            MLKitProcess.autoLabelPhotos(photos, arrPath);
         }
+        */
 
         //create gallery view if it doesn't exist, Gallery View Fragment will be loaded after successful login using loadGalleryFragment(), which is called inside the LoginFragment.
         /*if (galleryViewFragment == null) {
@@ -314,8 +320,57 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
     public void loadGalleryFragment(GoogleSignInClient mGoogleSignInClient) {
         this.mGoogleSignInClient = mGoogleSignInClient;
         //Create user object.
+
+
+        final String[] columns = {MediaStore.Images.Media.DATA, MediaStore.Images.Media._ID};
+        final String orderBy = MediaStore.Images.Media._ID;
+
+        //Stores all the images from the gallery in Cursor
+        Cursor cursor = getContentResolver().query(
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI, columns, null,
+                null, orderBy);
+        int count = cursor.getCount();
+
+        //Log.i("COUNT", "" + count);
+
+        //Create an array to store path to all the images
+        arrPath = new String[count];
+        //names = new String[count];
+
+        //loop through images on device and add paths to array
+        for (int i = 0; i < count; i++) {
+            cursor.moveToPosition(i);
+            int dataColumnIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA);
+            arrPath[i] = cursor.getString(dataColumnIndex);
+            Log.d("arrpath",arrPath[i]);
+            // names[i] = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
+
+            //Log.i("PATH", arrPath[i]);
+        }
+        cursor.close();
+
+        //get preferences
+
+
+
         acct = GoogleSignIn.getLastSignedInAccount(this);
         User userObj = new User(acct.getDisplayName(), acct.getEmail(), arrPath);
+
+
+        SharedPreferences shPref = PreferenceManager.getDefaultSharedPreferences(this);
+        //Handle auto tagging on device but not auto tagging off device
+        if(shPref.getBoolean("autoTagSwitch", false) && !shPref.getBoolean("serverTagSwitch", false)) {
+            Photo[] photos = new Photo[count]; //photo array to hold corrosponding arrPath information
+            for (int i = 0; i < count; i++) {  //for each path/photo
+                //String[] idArray = arrPath[i].split("/");
+                Photo photo = new Photo(arrPath[i], null, null, null);
+                photos[i] = photo;  //add photo to array
+            }
+            //send photos/paths to be labeled automatically
+            MLKitProcess.autoLabelPhotos(photos, arrPath);
+        }
+
+
         fm.beginTransaction().replace(R.id.main, GalleryViewFragment.newInstance(arrPath)).commit();
         //Only show settings and search button after logging in. This method is only called upon succesful login.
         searchButton.setVisible(true);

--- a/app/src/main/java/edu/temple/phototag/MainActivity.java
+++ b/app/src/main/java/edu/temple/phototag/MainActivity.java
@@ -116,7 +116,7 @@ public class MainActivity extends AppCompatActivity implements SettingsFragment.
                 photos[i] = photo;  //add photo to array
             }
             //send photos/paths to be labeled automatically
-            MLKitProcess.autoLabelPhotos(photos, arrPath);
+            MLKitProcess.autoLabelPhotos(photos);
         }
 
 

--- a/app/src/main/java/edu/temple/phototag/SinglePhotoViewFragment.java
+++ b/app/src/main/java/edu/temple/phototag/SinglePhotoViewFragment.java
@@ -112,7 +112,7 @@ public class SinglePhotoViewFragment extends Fragment {
         Arrays.fill(autoTags, null);
 
         //get and apply tags from ML Kit
-        MLKitProcess.labelImage(BitmapFactory.decodeFile(path));
+        MLKitProcess.labelImage(photo);
 
         return v;
     }


### PR DESCRIPTION
Adjusted the autotagging so that it should have identical results to iOS and result in less concurrent write issues. Overloaded MLKitProcess functions to accept photo objects rather than bitmaps or paths. 

Moved image path retrieval and gallery creation to happen after sign in which is also after permissions have been checked by the user, resulting in the gallery to load properly the first time the app is launched.